### PR TITLE
fix: add missing fields in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,16 @@
   "main": "lib/stark.js",
   "module": "lib/stark.js",
   "types": "lib/stark.d.ts",
+  "exports": {
+    ".": {
+      "import": "./lib/stark.js",
+      "require": "./lib/stark.js",
+      "types": "./lib/stark.d.ts"
+    }
+  },
+  "files": [
+    "lib"
+  ],
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
- Add `exports` field to support new "bundler"  moduleResolution with TS 5
- Add `files` field to publish entire lib folder for types 