### PR TITLE
chore: Loosen up the Starknet Peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@babel/preset-env": "^7.18.0",
         "@babel/preset-typescript": "^7.17.12",
         "@ledgerhq/hw-transport-mocker": "^6.29.4",
-        "@starknet-io/types-js": "^0.8.1",
+        "@starknet-io/types-js": "^0.10.0",
         "@types/jest": "^27.5.1",
         "@types/node": "^22.7.4",
         "babel-jest": "^30.0.0",
@@ -32,8 +32,15 @@
         "vite-plugin-dts": "^4.2.3"
       },
       "peerDependencies": {
-        "starknet": "^7.0.0"
+        "starknet": ">=7.0.0 <10.0.0"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -4170,11 +4177,82 @@
       }
     },
     "node_modules/@scure/base": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.1.tgz",
-      "integrity": "sha512-DGmGtC8Tt63J5GfHgfl5CuAXh96VF/LD8K9Hr/Gv0J2lAoRGlPOMpqMpMbCTOoOJMZCk2Xt+DskdDyn6dEFdzQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
       "license": "MIT",
       "peer": true,
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -4220,26 +4298,46 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
-    "node_modules/@starknet-io/starknet-types-07": {
-      "name": "@starknet-io/types-js",
+    "node_modules/@starknet-io/get-starknet-wallet-standard": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-wallet-standard/-/get-starknet-wallet-standard-5.0.0.tgz",
+      "integrity": "sha512-isDNGDlp16W24HE4IuweYXLDRZN0JbsDnazAieeKXE87Mn+jqhsjgTsMxcwWTjX7v906Bjz39FiDjGUddnr36g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@starknet-io/types-js": "^0.7.10",
+        "@wallet-standard/base": "^1.1.0",
+        "@wallet-standard/features": "^1.1.0",
+        "ox": "^0.4.4"
+      }
+    },
+    "node_modules/@starknet-io/get-starknet-wallet-standard/node_modules/@starknet-io/types-js": {
       "version": "0.7.10",
       "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
       "integrity": "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==",
       "license": "MIT",
       "peer": true
     },
-    "node_modules/@starknet-io/starknet-types-08": {
+    "node_modules/@starknet-io/starknet-types-010": {
       "name": "@starknet-io/types-js",
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.8.4.tgz",
-      "integrity": "sha512-0RZ3TZHcLsUTQaq1JhDSCM8chnzO4/XNsSCozwDET64JK5bjFDIf2ZUkta+tl5Nlbf4usoU7uZiDI/Q57kt2SQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.0.tgz",
+      "integrity": "sha512-7ALSydz6pq3YIOpq5a7OkkxqwJciMc9Nlph0OGjhcC3xX0xH30XgizmziLyYVN10oO9+BJk8M9KbJjpzdbtRSw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@starknet-io/starknet-types-09": {
+      "name": "@starknet-io/types-js",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.9.2.tgz",
+      "integrity": "sha512-vWOc0FVSn+RmabozIEWcEny1I73nDGTvOrLYJsR1x7LGA3AZmqt4i/aW69o/3i2NN5CVP8Ok6G1ayRQJKye3Wg==",
       "license": "MIT",
       "peer": true
     },
     "node_modules/@starknet-io/types-js": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.8.4.tgz",
-      "integrity": "sha512-0RZ3TZHcLsUTQaq1JhDSCM8chnzO4/XNsSCozwDET64JK5bjFDIf2ZUkta+tl5Nlbf4usoU7uZiDI/Q57kt2SQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.0.tgz",
+      "integrity": "sha512-7ALSydz6pq3YIOpq5a7OkkxqwJciMc9Nlph0OGjhcC3xX0xH30XgizmziLyYVN10oO9+BJk8M9KbJjpzdbtRSw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4653,6 +4751,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@wallet-standard/base": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.1.0.tgz",
+      "integrity": "sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wallet-standard/features": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.1.0.tgz",
+      "integrity": "sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@wallet-standard/base": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/abi-wan-kanabi": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/abi-wan-kanabi/-/abi-wan-kanabi-2.2.4.tgz",
@@ -4667,6 +4788,28 @@
       },
       "bin": {
         "generate": "dist/generate.js"
+      }
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/ajv": {
@@ -5867,6 +6010,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -10780,6 +10930,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ox": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.4.4.tgz",
+      "integrity": "sha512-oJPEeCDs9iNiPs6J0rTx+Y0KGeCGyCAA3zo94yZhm8G5WpOxrwUtn2Ie/Y8IyARSqqY/j9JTKA3Fc1xs1DvFnw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.10.1",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/bip32": "^1.5.0",
+        "@scure/bip39": "^1.4.0",
+        "abitype": "^1.0.6",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -11855,20 +12035,21 @@
       }
     },
     "node_modules/starknet": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/starknet/-/starknet-7.6.4.tgz",
-      "integrity": "sha512-FB20IaLCDbh/XomkB+19f5jmNxG+RzNdRO7QUhm7nfH81UPIt2C/MyWAlHCYkbv2wznSEb73wpxbp9tytokTgQ==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/starknet/-/starknet-9.2.0.tgz",
+      "integrity": "sha512-PGTKR/fFf3QBRwYc/3V5UiuSnRrP4BYQiGFpjZUSyI4zsbrDkUscRVutlQgFgCEiwM+4sVjsQnCzijNsXqSHZQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@noble/curves": "1.7.0",
-        "@noble/hashes": "1.6.0",
-        "@scure/base": "1.2.1",
+        "@noble/curves": "~1.7.0",
+        "@noble/hashes": "~1.6.0",
+        "@scure/base": "~1.2.1",
         "@scure/starknet": "1.1.0",
-        "@starknet-io/starknet-types-07": "npm:@starknet-io/types-js@~0.7.10",
-        "@starknet-io/starknet-types-08": "npm:@starknet-io/types-js@~0.8.4",
+        "@starknet-io/get-starknet-wallet-standard": "^5.0.0",
+        "@starknet-io/starknet-types-010": "npm:@starknet-io/types-js@0.10.0",
+        "@starknet-io/starknet-types-09": "npm:@starknet-io/types-js@~0.9.1",
         "abi-wan-kanabi": "2.2.4",
-        "lossless-json": "^4.0.1",
+        "lossless-json": "^4.2.0",
         "pako": "^2.0.4",
         "ts-mixer": "^6.0.3"
       },
@@ -12300,7 +12481,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@babel/preset-env": "^7.18.0",
     "@babel/preset-typescript": "^7.17.12",
     "@ledgerhq/hw-transport-mocker": "^6.29.4",
-    "@starknet-io/types-js": "^0.8.1",
+    "@starknet-io/types-js": "^0.10.0",
     "@types/jest": "^27.5.1",
     "@types/node": "^22.7.4",
     "babel-jest": "^30.0.0",
@@ -62,6 +62,6 @@
     "vite-plugin-dts": "^4.2.3"
   },
   "peerDependencies": {
-    "starknet": "^7.0.0"
+    "starknet": ">=7.0.0 <10.0.0"
   }
 }


### PR DESCRIPTION
We're running into update issues due to the version requirements of this package for the Starknet peer dependency.

This library requires Starknet v7.x.x, but it only uses a small subset of the Starknet client library, of which the functionality hasn't changed in versions v8 and v9.

This loosens up the peer dependency version to accept versions 7 to 9 and updates the build version to v9.2.0.